### PR TITLE
Avoid potential name collision issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## master
+* Avoid potential name collision issue  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#1](https://github.com/toshi0383/cmdshelf/pull/1)
+

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ I'm planning to support homebrew in future, but please build from source-code fo
 
 # TODO
 - Cache feature for blob
-- Potential command name collision issue (for now, first one is picked)
 - Support Makefile...?
 - Branch support for remote
 - Leave SwiftPM git tag version in .cmdshelf.yml


### PR DESCRIPTION
Added `run` sub-command to `remote` to avoid name collision with blobs and swiftpms.
With `blob`, user can give different alias to URL, so collision can be manually avoided.