### PR TITLE
Fix remote updating process: git pull => fetch and checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+##### Bugfix
+* Fix remote updating process: git pull => fetch and checkout  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#8](https://github.com/toshi0383/cmdshelf/pull/8)
+
 ## 0.2.1
 ##### Enhancements
 

--- a/Sources/cmdshelf/Configuration.swift
+++ b/Sources/cmdshelf/Configuration.swift
@@ -136,7 +136,8 @@ class Configuration {
         for repo in cmdshelfYml.remotes {
             let workspace = Const.remoteWorkspacePath + repo.name
             if workspace.isDirectory {
-                safeShellOutAndPrint(to: "cd \(workspace.string); git pull")
+                queuedPrintln("[\(repo.name)] Updating...")
+                safeShellOutAndPrint(to: "cd \(workspace.string); git fetch origin master; git checkout origin/master")
             }
         }
     }


### PR DESCRIPTION
remote updating doesn't fail anymore if user commits under `~/.cmdshelf/remote/repo`.