### PR TITLE
Easier install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,12 @@ bootstrap: build
 sourcery:
 	$(SOURCERY) --templates Resources/SourceryTemplates/AutoEquatables.stencil --sources Sources/$(MODULE_NAME)/ --output Sources/$(MODULE_NAME)/AutoEquatables.out.swift
 	# $(SOURCERY) --templates Resources/SourceryTemplates/LinuxMain.stencil --sources Tests/PbxprojTests/ --output Tests/LinuxMain.swift
+
+# Needs toshi0383/scripts to be added to cmdshelf's remote
+install:
+	cmdshelf run "ios/swiftpm/install.sh cmdshelf"
+
+release:
+	rm -rf .build/release
+	swift build -c release
+	cmdshelf run "ios/swiftpm/release.sh cmdshelf"

--- a/README.md
+++ b/README.md
@@ -140,10 +140,20 @@ If you need to update cloned repository, run `update` sub-command.
 Rebuild is performed for SwiftPM repos.
 
 # Install
-I'm planning to support homebrew in future, but please build from source-code for now.  
+## install.sh (beta)
+I've written install/release scripts for SwiftPM executable.  
+This should be the easiest way.
+```
+bash <(curl -sL https://raw.githubusercontent.com/toshi0383/scripts/master/ios/swiftpm/install.sh) cmdshelf
+```
+
+## Build from source
+
+Please build from source-code if `install.sh` didn't work.
 
 - Clone this repo and run `swift build -c release`.  
 - Executable will be created at `.build/release/cmdshelf`.
+- `mv .build/release/cmdshelf /usr/local/bin/`
 
 # TODO
 - Cache feature for blob


### PR DESCRIPTION
Install made easy.

# Motivation
There was no official way to distribute a SwiftPM executable. I've been looking for a way to install without building.
It's critical when it comes to CI build. You don't want to waste your build time by installing third party tool which takes couple minutes or more time to build.

# Problem

If built with `swift build` command, `@rpath` contains maintainer's `xcode-select -p` path which might not be compatible with other user's environment.

For example on my mac, `xcode-select -p` is `/Applications/Xcode8.3.2.app/Contents/Developer`.

So other users who don't have Xcode at same location as maintainer (me), binary install would fail with error `Image not found.`.

# Solution
By using `install_name_tool`, we manipulate binary's `LC_RPATH` to match user's Xcode location.

https://github.com/toshi0383/scripts/blob/master/ios/swiftpm/install.sh