### PR TITLE
blob add: convert relative path to absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   [Toshihiro Suzuki](https://github.com/toshi0383)
   [#27](https://github.com/toshi0383/cmdshelf/pull/27)
 
+##### Bugfix
+* [Fixed] blob adds relative path and `run` fails to execute.  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#28](https://github.com/toshi0383/cmdshelf/pull/28)
+
 ## 0.5.0
 ##### Enhancements
 * Linux Support  

--- a/Sources/cmdshelf/BlobCommand.swift
+++ b/Sources/cmdshelf/BlobCommand.swift
@@ -17,7 +17,7 @@ class BlobCommand: Group {
             let config = try Configuration()
             let path = Path(url)
             if path.exists {
-                config.cmdshelfYml.blobs.append(Blob(name: name, localPath: path.string))
+                config.cmdshelfYml.blobs.append(Blob(name: name, localPath: path.absolute().string))
             } else {
                 config.cmdshelfYml.blobs.append(Blob(name: name, url: url))
             }


### PR DESCRIPTION
`blob` was adding localPath as relative path and `run` was failing to execute it.