### PR TITLE
Add S and L option to curl command of `run` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
   [Toshihiro Suzuki](https://github.com/toshi0383)
   [#27](https://github.com/toshi0383/cmdshelf/pull/27)
 
+* Add S and L option to curl command of `run`  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#29](https://github.com/toshi0383/cmdshelf/pull/29)
+
 ##### Bugfix
 * [Fixed] blob adds relative path and `run` fails to execute.  
   [Toshihiro Suzuki](https://github.com/toshi0383)

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -59,7 +59,7 @@ let group = Group { group in
         if let url = config.cmdshelfYml.blobURL(for: name) {
             // TODO:
             //   if let localURL = config.cache(for: url) {
-            shellOut(to: "bash <(curl -s \"\(url)\")", arguments: parameters)
+            shellOut(to: "bash <(curl -sSL \"\(url)\")", arguments: parameters)
             return
         } else if let localPath = config.cmdshelfYml.blobLocalPath(for: name) {
             shellOut(to: localPath, arguments: parameters)


### PR DESCRIPTION
- [x] `blob` URL now follows location header
- [x] `run` will print network error on fetching a `blob`