### PR TITLE
Introduce new COMMAND argument syntax to distinguish remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   [Toshihiro Suzuki](https://github.com/toshi0383)
   [#33](https://github.com/toshi0383/cmdshelf/pull/33)
 
+* Introduce new COMMAND argument syntax to distinguish remotes  
+  `"[remoteName:]my/command [parameter ...]"`  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#34](https://github.com/toshi0383/cmdshelf/pull/34)
+
 ## 0.6.0
 ##### Enhancements
 * Add cat command  

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -43,11 +43,7 @@ struct VaradicAliasArgument: ArgumentDescriptor {
     let description: String? = "[[remoteName:]my/command ...]"
     let type: ArgumentType = .argument
     func parse(_ parser: ArgumentParser) throws -> ValueType {
-        let remainder = parser.remainder
-        for _ in remainder {
-            _ = parser.shift()
-        }
-        return remainder.flatMap(AliasParser.parse)
+        return parser.shiftAll().flatMap(AliasParser.parse)
     }
 }
 
@@ -64,5 +60,16 @@ struct AliasParameterArgument: ArgumentDescriptor {
             throw ArgumentError.missingValue(argument: "COMMAND")
         }
         return (alias, ParameterParser.parse(string))
+    }
+}
+
+// MARK: - Commander extension
+extension ArgumentParser {
+    func shiftAll() -> [String] {
+        let _remainder = remainder
+        for _ in remainder {
+            _ = shift()
+        }
+        return _remainder
     }
 }

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -46,7 +46,7 @@ private class ParameterParser {
 struct VaradicAliasArgument: ArgumentDescriptor {
     typealias ValueType = [Alias]
     let name: String = "[COMMAND ...]"
-    let description: String? = nil
+    let description: String? = "[[remoteName:]my/command ...]"
     let type: ArgumentType = .argument
     func parse(_ parser: ArgumentParser) throws -> ValueType {
         let remainder = parser.remainder
@@ -60,7 +60,7 @@ struct VaradicAliasArgument: ArgumentDescriptor {
 struct AliasParameterArgument: ArgumentDescriptor {
     typealias ValueType = (alias: Alias, parameter: String?)
     let name: String = "COMMAND"
-    let description: String? = "command name alias\n double or single quoted when passing arguments. e.g. `cmdshelf run \"myscript --option someargument\"\nTo avoid name collision, add remote name separated by :. e.g. `cmdshelf run my-remote:my/script`"
+    let description: String? = "\"[remoteName:]my/command [parameter ...]\"\n    -   double or single quoted when passing arguments. e.g. `cmdshelf run \"myscript --option someargument\"\n    -   To avoid name collision, add remote name separated by \":\". e.g. `cmdshelf run my-remote:my/script`"
     let type: ArgumentType = .argument
     func parse(_ parser: ArgumentParser) throws -> ValueType {
         guard let string = parser.shift() else {

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -1,0 +1,67 @@
+import Commander
+import Foundation
+
+struct Alias {
+    let alias: String
+    let remoteName: String?
+    var fullAlias: String {
+        if let remoteName = remoteName {
+            return "\(remoteName):\(alias)"
+        } else {
+            return alias
+        }
+    }
+    static let empty = Alias(alias: "", remoteName: nil)
+}
+
+class AliasParser {
+    static func parse(_ string: String) -> Alias {
+        let components = string.components(separatedBy: " ")
+        guard let _alias = components.first else {
+            return .empty
+        }
+        let alias: String
+        let remoteName: String?
+        if _alias.contains(":") {
+            remoteName = _alias.components(separatedBy: ":").first!
+            alias = _alias.components(separatedBy: ":").dropFirst().joined()
+        } else {
+            alias = _alias
+            remoteName = nil
+        }
+        return Alias(alias: alias, remoteName: remoteName)
+    }
+}
+
+class ParameterParser {
+    static func parse(_ string: String) -> String {
+        return string.components(separatedBy: " ").dropFirst().joined()
+    }
+}
+
+struct VaradicAliasArgument: ArgumentDescriptor {
+    typealias ValueType = [Alias]
+    let name: String = "[COMMAND ...]"
+    let description: String? = nil
+    let type: ArgumentType = .argument
+    func parse(_ parser: ArgumentParser) throws -> ValueType {
+        let remainder = parser.remainder
+        for _ in remainder {
+            _ = parser.shift()
+        }
+        return remainder.map(AliasParser.parse)
+    }
+}
+
+struct AliasParameterArgument: ArgumentDescriptor {
+    typealias ValueType = (alias: Alias, parameter: String)
+    let name: String = "COMMAND"
+    let description: String? = "command name alias\n double or single quoted when passing arguments. e.g. `cmdshelf run \"myscript --option someargument\"\nTo avoid name collision, add remote name separated by :. e.g. `cmdshelf run my-remote:my/script`"
+    let type: ArgumentType = .argument
+    func parse(_ parser: ArgumentParser) throws -> ValueType {
+        guard let string = parser.shift() else {
+            throw ArgumentError.missingValue(argument: name)
+        }
+        return (AliasParser.parse(string), ParameterParser.parse(string))
+    }
+}

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -11,15 +11,13 @@ struct Alias {
             return alias
         }
     }
-    static let empty = Alias(alias: "", remoteName: nil)
 }
 
 class AliasParser {
     static func parse(_ string: String) -> Alias {
-        let components = string.components(separatedBy: " ")
-        guard let _alias = components.first else {
-            return .empty
-        }
+        // Get "remote:my/script" part.
+        // `"".components(separatedBy: " ").count` is 1, so force unwrap.
+        let _alias  = string.components(separatedBy: " ").first!
         let alias: String
         let remoteName: String?
         if _alias.contains(":") {
@@ -49,7 +47,7 @@ struct VaradicAliasArgument: ArgumentDescriptor {
         for _ in remainder {
             _ = parser.shift()
         }
-        return remainder.map(AliasParser.parse)
+        return remainder.map(AliasParser.parse).filter { !$0.alias.isEmpty }
     }
 }
 

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -4,13 +4,7 @@ import Foundation
 struct Alias {
     let alias: String
     let remoteName: String?
-    var fullAlias: String {
-        if let remoteName = remoteName {
-            return "\(remoteName):\(alias)"
-        } else {
-            return alias
-        }
-    }
+    let originalValue: String
 }
 
 private class AliasParser {
@@ -30,7 +24,7 @@ private class AliasParser {
             alias = _alias
             remoteName = nil
         }
-        return Alias(alias: alias, remoteName: remoteName)
+        return Alias(alias: alias, remoteName: remoteName, originalValue: _alias)
     }
 }
 

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -39,8 +39,8 @@ private class ParameterParser {
 
 struct VaradicAliasArgument: ArgumentDescriptor {
     typealias ValueType = [Alias]
-    let name: String = "[COMMAND ...]"
-    let description: String? = "[[remoteName:]my/command ...]"
+    let name: String = "[\(Message.COMMAND) ...]"
+    let description: String? = nil
     let type: ArgumentType = .argument
     func parse(_ parser: ArgumentParser) throws -> ValueType {
         return parser.shiftAll().flatMap(AliasParser.parse)
@@ -49,8 +49,8 @@ struct VaradicAliasArgument: ArgumentDescriptor {
 
 struct AliasParameterArgument: ArgumentDescriptor {
     typealias ValueType = (alias: Alias, parameter: String?)
-    let name: String = "COMMAND"
-    let description: String? = "\"[remoteName:]my/command [parameter ...]\"\n    -   double or single quoted when passing arguments. e.g. `cmdshelf run \"myscript --option someargument\"\n    -   To avoid name collision, add remote name separated by \":\". e.g. `cmdshelf run my-remote:my/script`"
+    let name: String = "\"\(Message.COMMAND) [parameter ...]\""
+    let description: String? = "Double or single quote when passing arguments. e.g. `cmdshelf run \"myscript --option someargument\""
     let type: ArgumentType = .argument
     func parse(_ parser: ArgumentParser) throws -> ValueType {
         guard let string = parser.shift() else {

--- a/Sources/cmdshelf/BlobCommand.swift
+++ b/Sources/cmdshelf/BlobCommand.swift
@@ -23,7 +23,7 @@ class BlobCommand: Group {
             }
         })
         addCommand("remove", "Remove a blob.", Commander.command(
-            Argument<String>("NAME", description: "command name")
+            Argument<String>("NAME", description: "command name alias")
             ) { name in
             let config = try Configuration()
             config.cmdshelfYml.removeBlob(name: name)

--- a/Sources/cmdshelf/Configuration.swift
+++ b/Sources/cmdshelf/Configuration.swift
@@ -146,9 +146,9 @@ class Configuration {
         let allRemoteCommands = try cmdshelfYml.remotes
             .map { $0.name }
             .flatMap {
-                let commands = try self.displayNames(for: $0, type: displayType)
+                let names = try self.displayNames(for: $0, type: displayType)
                     .joined(separator: "\n    ")
-                return "  \($0):\n    \(commands)"
+                return "  \($0):\n    \(names)"
             }
             .joined(separator: "\n\n")
         if cmdshelfYml.blobs.isEmpty == false {

--- a/Sources/cmdshelf/Configuration.swift
+++ b/Sources/cmdshelf/Configuration.swift
@@ -128,7 +128,7 @@ class Configuration {
             if let url = cmdshelfYml.blobURL(for: alias) {
                 // TODO:
                 //   if let localURL = config.cache(for: url) {
-                contexts.append(Context(location: "bash <(curl -sSL \"\(url)\")"))
+                contexts.append(Context(location: "curl -sSL \"\(url)\""))
             } else if let localPath = cmdshelfYml.blobLocalPath(for: alias) {
                 contexts.append(Context(location: localPath))
             }

--- a/Sources/cmdshelf/Configuration.swift
+++ b/Sources/cmdshelf/Configuration.swift
@@ -90,7 +90,7 @@ class Configuration {
             }
         }
     }
-    func getContextForRemote(alias: String, remoteName: String? = nil) -> Context? {
+    private func getContextForRemote(alias: String, remoteName: String? = nil) -> Context? {
         return cmdshelfYml.remotes
             .filter {
                 if let remoteName = remoteName {

--- a/Sources/cmdshelf/Context.swift
+++ b/Sources/cmdshelf/Context.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct Context {
+    let location: String
+}

--- a/Sources/cmdshelf/Functions.swift
+++ b/Sources/cmdshelf/Functions.swift
@@ -2,15 +2,19 @@ import Foundation
 import Reporter
 
 @discardableResult
-func silentShellOut(to: String, argument: String = "") -> Int32 {
+func silentShellOut(to: String, argument: String? = nil) -> Int32 {
     return shellOut(to: to, argument: argument, shouldPrintStdout: false, shouldPrintError: false)
 }
 
 @discardableResult
-func shellOut(to: String, argument: String = "", shouldPrintStdout: Bool = true, shouldPrintError: Bool = true) -> Int32 {
+func shellOut(to: String, argument: String? = nil, shouldPrintStdout: Bool = true, shouldPrintError: Bool = true) -> Int32 {
     let process = Process()
     process.launchPath = "/bin/bash"
-    process.arguments = ["-c", "\(to) \(argument)"]
+    if let arg = argument {
+        process.arguments = ["-c", "\(to) \(arg)"]
+    } else {
+        process.arguments = ["-c", "\(to)"]
+    }
     #if !os(Linux)
     let inPipe = Pipe()
     inPipe.fileHandleForWriting.writeabilityHandler = { handler in

--- a/Sources/cmdshelf/Functions.swift
+++ b/Sources/cmdshelf/Functions.swift
@@ -2,15 +2,15 @@ import Foundation
 import Reporter
 
 @discardableResult
-func silentShellOut(to: String, arguments: [String] = []) -> Int32 {
-    return shellOut(to: to, arguments: arguments, shouldPrintStdout: false, shouldPrintError: false)
+func silentShellOut(to: String, argument: String = "") -> Int32 {
+    return shellOut(to: to, argument: argument, shouldPrintStdout: false, shouldPrintError: false)
 }
 
 @discardableResult
-func shellOut(to: String, arguments: [String] = [], shouldPrintStdout: Bool = true, shouldPrintError: Bool = true) -> Int32 {
+func shellOut(to: String, argument: String = "", shouldPrintStdout: Bool = true, shouldPrintError: Bool = true) -> Int32 {
     let process = Process()
     process.launchPath = "/bin/bash"
-    process.arguments = ["-c", "\(to) \(arguments.joined(separator: " "))"]
+    process.arguments = ["-c", "\(to) \(argument)"]
     #if !os(Linux)
     let inPipe = Pipe()
     inPipe.fileHandleForWriting.writeabilityHandler = { handler in
@@ -38,4 +38,3 @@ func shellOut(to: String, arguments: [String] = [], shouldPrintStdout: Bool = tr
     #endif
     return process.terminationStatus
 }
-

--- a/Sources/cmdshelf/Messages.swift
+++ b/Sources/cmdshelf/Messages.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum Message {
+    static let COMMAND = "[remoteName:]my/script"
     static func noSuchCommand(_ commandName: String) -> String {
         return "cmdshelf: \(commandName): No such command"
     }

--- a/Sources/cmdshelf/Messages.swift
+++ b/Sources/cmdshelf/Messages.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum Message {
+    static func noSuchCommand(_ commandName: String) -> String {
+        return "cmdshelf: \(commandName): No such command"
+    }
+}

--- a/Sources/cmdshelf/RemoteCommand.swift
+++ b/Sources/cmdshelf/RemoteCommand.swift
@@ -18,7 +18,7 @@ class RemoteCommand: Group {
             config.cmdshelfYml.remotes.append(Repository(name: name, url: url, tag: nil, branch: nil))
         })
         addCommand("remove", "Remove a remote.", Commander.command(
-            Argument<String>("NAME", description: "command name")
+            Argument<String>("NAME", description: "remote name")
         ) { name in
             let config = try Configuration()
             config.cmdshelfYml.removeRemote(name: name)

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -26,7 +26,7 @@ let group = Group { group in
             for alias in aliases {
                 // Search in blobs and remote
                 guard let context = config.getContexts(for: alias.alias, remoteName: alias.remoteName).first else {
-                    queuedPrintlnError(Message.noSuchCommand(alias.fullAlias))
+                    queuedPrintlnError(Message.noSuchCommand(alias.originalValue))
                     failure = true
                     continue
                 }
@@ -50,7 +50,7 @@ let group = Group { group in
         let parameter = aliasParam.parameter
         // Search in blobs and remote
         guard let context = config.getContexts(for: alias, remoteName: remoteName).first else {
-            queuedPrintlnError(Message.noSuchCommand(aliasParam.0.fullAlias))
+            queuedPrintlnError(Message.noSuchCommand(aliasParam.0.originalValue))
             exit(1)
         }
         shellOut(to: context.location, argument: parameter)

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -50,7 +50,7 @@ let group = Group { group in
         let parameter = aliasParam.parameter
         // Search in blobs and remote
         guard let context = config.getContexts(for: alias, remoteName: remoteName).first else {
-            queuedPrintlnError(Message.noSuchCommand(aliasParam.0.originalValue))
+            queuedPrintlnError(Message.noSuchCommand(aliasParam.alias.originalValue))
             exit(1)
         }
         shellOut(to: context.location, argument: parameter)

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -53,7 +53,11 @@ let group = Group { group in
             queuedPrintlnError(Message.noSuchCommand(aliasParam.alias.originalValue))
             exit(1)
         }
-        shellOut(to: context.location, argument: parameter)
+        if context.location.hasPrefix("curl ") {
+            shellOut(to: "bash <(\(context.location))", argument: parameter)
+        } else {
+            shellOut(to: context.location, argument: parameter)
+        }
     })
     group.addCommand("update", command() {
         let config = try Configuration()

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -7,7 +7,7 @@ let version = "0.6.0"
 
 let group = Group { group in
     group.addCommand("list", command(
-        Flag("path", disabledName: "", description: "display absolute path instead of command alias name", default: false)
+        Flag("path", disabledName: "", description: "display absolute path instead of command name alias", default: false)
         ) { isPath in
         let config = try Configuration()
         try config.printAllCommands(displayType: isPath ? .absolutePath : .alias)

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -15,68 +15,45 @@ let group = Group { group in
     group.addCommand("remote", RemoteCommand())
     group.addCommand("blob", BlobCommand())
     group.addCommand("cat", "concatenate and print commands", command(
-        VariadicArgument<String>("COMMAND", description: "command name")
-    ) { (commands) in
-        if commands.isEmpty {
+        VaradicAliasArgument()
+    ) { (aliases) in
+        if aliases.isEmpty {
             shellOut(to: "cat")
         } else {
             let config = try Configuration()
+            config.cloneRemotesIfNeeded()
             var failure = false
-            for name in commands {
-                // Search in blob
-                if let url = config.cmdshelfYml.blobURL(for: name) {
-                    // TODO:
-                    //   if let localURL = config.cache(for: url) {
-                    shellOut(to: "curl -sSL \"\(url)\"")
-                    continue
-                } else if let localPath = config.cmdshelfYml.blobLocalPath(for: name) {
-                    shellOut(to: "cat \(localPath)")
+            for alias in aliases {
+                // Search in blobs and remote
+                guard let context = config.getContexts(for: alias.alias, remoteName: alias.remoteName).first else {
+                    queuedPrintlnError(Message.noSuchCommand(alias.fullAlias))
+                    failure = true
                     continue
                 }
-
-                // Search in remote
-                config.cloneRemotesIfNeeded()
-                if let localPath = config.remote(for: name) {
-                    shellOut(to: "cat \(localPath)")
-                    continue
+                if context.location.hasPrefix("curl ") {
+                    shellOut(to: context.location)
+                } else {
+                    shellOut(to: "cat \(context.location)")
                 }
-                queuedPrintln("cat: \(name): No such file or directory")
-                failure = true
             }
             if failure {
                 exit(1)
             }
         }
     })
-    group.addCommand("run", command(
-        Argument<String>("COMMAND", description: "command name alias double or single quoted when passing arguments. e.g. `cmdshelf run \"myscript --option someargument\"")
-    ) { (command) in
-        guard let name = command.components(separatedBy: " ").first else {
-            return
-        }
-        let parameters = command.components(separatedBy: " ").dropFirst().map { $0 }
+    group.addCommand("run", "Run command", command(
+        AliasParameterArgument()
+    ) { (aliasParam) in
         let config = try Configuration()
-
-        // Search in blob
-        if let url = config.cmdshelfYml.blobURL(for: name) {
-            // TODO:
-            //   if let localURL = config.cache(for: url) {
-            shellOut(to: "bash <(curl -sSL \"\(url)\")", arguments: parameters)
-            return
-        } else if let localPath = config.cmdshelfYml.blobLocalPath(for: name) {
-            shellOut(to: localPath, arguments: parameters)
-            return
+        let alias = aliasParam.alias.alias
+        let remoteName = aliasParam.alias.remoteName
+        let parameter = aliasParam.parameter
+        // Search in blobs and remote
+        guard let context = config.getContexts(for: alias, remoteName: remoteName).first else {
+            queuedPrintlnError(Message.noSuchCommand(aliasParam.0.fullAlias))
+            exit(1)
         }
-
-        // Search in remote
-        config.cloneRemotesIfNeeded()
-        if let localPath = config.remote(for: name) {
-            shellOut(to: localPath.string, arguments: parameters)
-            return
-        }
-
-        queuedPrintlnError("Command `\(command)` not found.")
-        exit(1)
+        shellOut(to: context.location, argument: parameter)
     })
     group.addCommand("update", command() {
         let config = try Configuration()


### PR DESCRIPTION
`cmdshelf` can now distinguish remotes from `COMMAND` argument.

# Syntax
```
[remoteName:]my/command
```

Left hand side of `:` becomes a remote name.
If remote's name is omitted, first one found is picked.

# Usage
## with `run`
```
$ cmdshelf run "toshi0383-scripts:twitter/bearer hoge fuga"
$ cmdshelf run "twitter/bearer hoge fuga" # remote name can be omitted.
```

## with `cat`
```
$ cmdshelf cat "toshi0383-scripts:twitter/bearer hoge fuga"
$ cmdshelf cat "twitter/bearer hoge fuga" # remote name can be omitted.
```