### PR TITLE
Add description for each commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.7.1
+## master
+##### Enhancements
+* Add description for each commands  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#39](https://github.com/toshi0383/cmdshelf/pull/39)
+
 ##### Bugfix
 * [fixed] run concats all parameters  
   [Toshihiro Suzuki](https://github.com/toshi0383)

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -6,15 +6,15 @@ import Reporter
 let version = "0.7.1"
 
 let group = Group { group in
-    group.addCommand("list", command(
+    group.addCommand("list", "Show all registered commands (use --path to print absolute paths)", command(
         Flag("path", default: false, disabledName: "", description: "display absolute path instead of command name alias")
         ) { isPath in
         let config = try Configuration()
         try config.printAllCommands(displayType: isPath ? .absolutePath : .alias)
     })
-    group.addCommand("remote", RemoteCommand())
-    group.addCommand("blob", BlobCommand())
-    group.addCommand("cat", "concatenate and print commands", command(
+    group.addCommand("remote", "Manage remote commands (type `cmdshelf remote --help` for usage)", RemoteCommand())
+    group.addCommand("blob", "Manage blob commands (type `cmdshelf blob --help` for usage)", BlobCommand())
+    group.addCommand("cat", "Concatenate and print commands", command(
         VaradicAliasArgument()
     ) { (aliases) in
         if aliases.isEmpty {
@@ -59,7 +59,7 @@ let group = Group { group in
             shellOut(to: context.location, argument: parameter)
         }
     })
-    group.addCommand("update", command() {
+    group.addCommand("update", "Update all cloned repositories", command() {
         let config = try Configuration()
         config.cloneRemotesIfNeeded()
         config.updateRemotes()


### PR DESCRIPTION
Fixes https://github.com/toshi0383/cmdshelf/issues/31

```
cmdshelf $ cmdshelf-debug --help
Usage:

    $ /Users/toshi0383/Documents/workspace/cmdshelf/.build/debug/cmdshelf

Commands:

    + list - Show all registered commands (use --path to print absolute paths)
    + remote - Manage remote commands (type `cmdshelf remote --help` for usage)
    + blob - Manage blob commands (type `cmdshelf blob --help` for usage)
    + cat - Concatenate and print commands
    + run - Run command
    + update - Update all cloned repositories

```