### PR TITLE
No need to quote command and parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+##### Enhancements
+* No need to quote command with parameters  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#43](https://github.com/toshi0383/cmdshelf/pull/43)
+
 ## 0.7.2
 ##### Enhancements
 * Add description for each commands  

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/toshi0383/Commander.git",
         "state": {
           "branch": null,
-          "revision": "0724718584eaac17829d9ad1ca973ac232111bcc",
-          "version": "0.8.5"
+          "revision": "098df1ac4aba66185777c8bac0db20c4df98b4cc",
+          "version": "0.9.1"
         }
       },
       {

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -63,6 +63,31 @@ struct AliasParameterArgument: ArgumentDescriptor {
     }
 }
 
+enum SubCommand: String {
+    case run, list, remote, blob, cat, update
+}
+
+struct SubCommandConvertibleArgument: ArgumentDescriptor {
+
+    typealias ValueType = (SubCommand, parser: ArgumentParser)?
+
+    let name: String = "\"\(Message.COMMAND) [parameter ...]\""
+    let description: String? = "Double or single quote when passing arguments. e.g. `cmdshelf run \"myscript --option someargument\""
+    let type: ArgumentType = .argument
+
+    func parse(_ parser: ArgumentParser) throws -> ValueType {
+        if let string = parser.shift() {
+            if let subCommand = SubCommand(rawValue: string) {
+                return (subCommand, parser)
+            } else {
+                throw ArgumentError.invalidType(value: string, type: "SubCommand", argument: nil)
+            }
+        } else {
+            return nil
+        }
+    }
+}
+
 // MARK: - Commander extension
 extension ArgumentParser {
     func shiftAll() -> [String] {

--- a/Sources/cmdshelf/BlobCommand.swift
+++ b/Sources/cmdshelf/BlobCommand.swift
@@ -4,6 +4,8 @@ import PathKit
 import Reporter
 
 class BlobCommand: Group {
+    let name: String = "blob"
+    let description: String? = "Manage blob commands (type `cmdshelf blob` for usage)"
     override init() {
         super.init()
         addCommand("list", "Show registered blobs.", Commander.command() {

--- a/Sources/cmdshelf/RemoteCommand.swift
+++ b/Sources/cmdshelf/RemoteCommand.swift
@@ -4,6 +4,8 @@ import Foundation
 import Reporter
 
 class RemoteCommand: Group {
+    let name: String = "remote"
+    let description: String? = "Manage remote commands (type `cmdshelf remote` for usage)"
     override init() {
         super.init()
         addCommand("list", "Show registered remotes.", Commander.command() {

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -5,65 +5,100 @@ import Reporter
 
 let version = "0.7.2"
 
-let group = Group { group in
-    group.addCommand("list", "Show all registered commands (use --path to print absolute paths)", command(
-        Flag("path", default: false, disabledName: "", description: "display absolute path instead of command name alias")
-        ) { isPath in
-        let config = try Configuration()
-        try config.printAllCommands(displayType: isPath ? .absolutePath : .alias)
-    })
-    group.addCommand("remote", "Manage remote commands (type `cmdshelf remote --help` for usage)", RemoteCommand())
-    group.addCommand("blob", "Manage blob commands (type `cmdshelf blob --help` for usage)", BlobCommand())
-    group.addCommand("cat", "Concatenate and print commands", command(
-        VaradicAliasArgument()
-    ) { (aliases) in
-        if aliases.isEmpty {
-            shellOut(to: "cat")
-        } else {
-            let config = try Configuration()
-            config.cloneRemotesIfNeeded()
-            var failure = false
-            for alias in aliases {
-                // Search in blobs and remote
-                guard let context = config.getContexts(for: alias.alias, remoteName: alias.remoteName).first else {
-                    queuedPrintlnError(Message.noSuchCommand(alias.originalValue))
-                    failure = true
-                    continue
-                }
-                if context.location.hasPrefix("curl ") {
-                    shellOut(to: context.location)
-                } else {
-                    shellOut(to: "cat \(context.location)")
-                }
-            }
-            if failure {
-                exit(1)
-            }
-        }
-    })
-    group.addCommand("run", "Run command", command(
-        AliasParameterArgument()
-    ) { (aliasParam) in
-        let config = try Configuration()
-        let alias = aliasParam.alias.alias
-        let remoteName = aliasParam.alias.remoteName
-        let parameter = aliasParam.parameter
-        // Search in blobs and remote
-        guard let context = config.getContexts(for: alias, remoteName: remoteName).first else {
-            queuedPrintlnError(Message.noSuchCommand(aliasParam.alias.originalValue))
-            exit(1)
-        }
-        if context.location.hasPrefix("curl ") {
-            shellOut(to: "bash <(\(context.location))", argument: parameter)
-        } else {
-            shellOut(to: context.location, argument: parameter)
-        }
-    })
-    group.addCommand("update", "Update all cloned repositories", command() {
+let blob = BlobCommand()
+let cat = command(VaradicAliasArgument()) { (aliases) in
+    if aliases.isEmpty {
+        shellOut(to: "cat")
+    } else {
         let config = try Configuration()
         config.cloneRemotesIfNeeded()
-        config.updateRemotes()
-    })
+        var failure = false
+        for alias in aliases {
+            // Search in blobs and remote
+            guard let context = config.getContexts(for: alias.alias, remoteName: alias.remoteName).first else {
+                queuedPrintlnError(Message.noSuchCommand(alias.originalValue))
+                failure = true
+                continue
+            }
+            if context.location.hasPrefix("curl ") {
+                shellOut(to: context.location)
+            } else {
+                shellOut(to: "cat \(context.location)")
+            }
+        }
+        if failure {
+            exit(1)
+        }
+    }
 }
 
-group.run(version)
+let help = command(SubCommandArgument()) { (subCommand) in
+    if let subCommand = subCommand {
+        queuedPrintln(subCommand.helpMessage)
+        return
+    }
+
+    queuedPrintln("Usage:")
+    queuedPrintln("")
+    queuedPrintln("    $ cmdshelf")
+    queuedPrintln("")
+    queuedPrintln("Commands:")
+    queuedPrintln("")
+    queuedPrintln("    + list - Show all registered commands (use --path to print absolute paths)")
+    queuedPrintln("    + remote - Manage remote commands (type `cmdshelf remote` for usage)")
+    queuedPrintln("    + blob - Manage blob commands (type `cmdshelf blob` for usage)")
+    queuedPrintln("    + cat - concatenate and print commands")
+    queuedPrintln("    + run - Run command")
+    queuedPrintln("    + update - Update all cloned repositories")
+}
+
+let list = command(
+    Flag("path", default: false, disabledName: "", description: "display absolute path instead of command name alias")
+) { isPath in
+    let config = try Configuration()
+    try config.printAllCommands(displayType: isPath ? .absolutePath : .alias)
+}
+
+let remote = RemoteCommand()
+
+let run = command(AliasParameterArgument()) { (aliasParam) in
+    let config = try Configuration()
+    let alias = aliasParam.alias.alias
+    let remoteName = aliasParam.alias.remoteName
+    let parameter = aliasParam.parameter
+    // Search in blobs and remote
+    guard let context = config.getContexts(for: alias, remoteName: remoteName).first else {
+        queuedPrintlnError(Message.noSuchCommand(aliasParam.alias.originalValue))
+        exit(1)
+    }
+    if context.location.hasPrefix("curl ") {
+        shellOut(to: "bash <(\(context.location))", argument: parameter)
+    } else {
+        shellOut(to: context.location, argument: parameter)
+    }
+}
+
+let update = command() {
+    let config = try Configuration()
+    config.cloneRemotesIfNeeded()
+    config.updateRemotes()
+}
+
+let c = command(SubCommandConvertibleArgument())
+{ (tuple) in
+    if let (subCommand, parser) = tuple {
+        switch subCommand {
+        case .blob: try blob.run(parser)
+        case .cat: try cat.run(parser)
+        case .list: try list.run(parser)
+        case .remote: try remote.run(parser)
+        case .run: try run.run(parser)
+        case .help: try help.run(parser)
+        case .update: try update.run(parser)
+        }
+    } else {
+        // TODO: interactive mode
+    }
+}
+
+c.run(version)


### PR DESCRIPTION
No need to quote commands with parameters anymore.

# Before
``` 
$ cmdshelf run echo-sd hello
Unknown Arguments: hello
```

# After
```
$ cmdshelf run echo-sd hello
＿人人人人＿
＞　hello　＜
￣Y^Y^Y^Y^￣
```

# Breaking development-side change
This disables automatic help message generation of Commander.
So I will
- [ ] improve help message by cmdshelf itself.