### PR TITLE
set error status code on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 ##### Bugfix & Breaking
+* [fixed] set error status code on error [#52](https://github.com/toshi0383/cmdshelf/pull/52)  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+
 * [fixed] Quoted parameter is unquoted [#49](https://github.com/toshi0383/cmdshelf/issues/49)  
   [Toshihiro Suzuki](https://github.com/toshi0383)
   [#50](https://github.com/toshi0383/cmdshelf/issues/50)  

--- a/Sources/cmdshelf/Error.swift
+++ b/Sources/cmdshelf/Error.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 struct CmdshelfError: Error, CustomStringConvertible {
-    let message: String
-    init(_ message: String) {
+    let message: String?
+    init(_ message: String? = nil) {
         self.message = message
     }
     var description: String {
-        return message
+        return message ?? ""
     }
 }

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -23,7 +23,7 @@ let blob = BlobCommand()
 
 let cat = command(VaradicAliasArgument()) { (aliases) in
     if aliases.isEmpty {
-        shellOut(to: "cat")
+        exit(shellOut(to: "cat"))
     } else {
         let config = try Configuration()
         config.cloneRemotesIfNeeded()
@@ -36,9 +36,13 @@ let cat = command(VaradicAliasArgument()) { (aliases) in
                 continue
             }
             if context.location.hasPrefix("curl ") {
-                shellOut(to: context.location)
+                if shellOut(to: context.location) > 0 {
+                    failure = true
+                }
             } else {
-                shellOut(to: "cat \(context.location)")
+                if shellOut(to: "cat \(context.location)") > 0 {
+                    failure = true
+                }
             }
         }
         if failure {
@@ -80,9 +84,9 @@ let run = command(AliasParameterArgument()) { (aliasParam) in
     }
     let singleQuoted = parameters.map { "\'\($0)\'" }.joined(separator: " ")
     if context.location.hasPrefix("curl ") {
-        shellOut(to: "bash <(\(context.location))", argument: singleQuoted)
+        exit(shellOut(to: "bash <(\(context.location))", argument: singleQuoted))
     } else {
-        shellOut(to: context.location, argument: singleQuoted)
+        exit(shellOut(to: context.location, argument: singleQuoted))
     }
 }
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# WARNING!: currently this test modifies your local environment
+#
 STATUS=0
 set +e
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -139,7 +139,7 @@ then
     STATUS=1
 fi
 
-## 010: exit status code
+## 008: exit status code
 before_each
 
 $CMDSHELF cat nsc01 nsc02 2> /dev/null
@@ -148,9 +148,28 @@ exit_status=$?
 if [ $exit_status -ne 1 ]
 then
     echo Exit code is expected to be 1 but was $exit_status
-    echo 010 FAILED
+    echo 008 FAILED
     STATUS=1
 fi
+
+## 009: [run] underlying exit status code
+before_each
+
+TEST_009_SH=~/.cmdshelf/remote/_cmdshelf-remote/009.sh
+printf "#!/bin/bash\nexit 1" > $TEST_009_SH
+chmod +x $TEST_009_SH
+
+$CMDSHELF run 009.sh
+exit_status=$?
+
+if [ $exit_status -ne 1 ]
+then
+    echo Exit code is expected to be 1 but was $exit_status
+    echo 009 FAILED
+    STATUS=1
+fi
+
+rm $TEST_009_SH
 
 # Cleanup
 after_all

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -126,6 +126,19 @@ fi
 
 rm $TMP_006 $TEST_006_SH
 
+## 007: exit status code
+before_each
+
+$CMDSHELF run no-such-command 2> /dev/null
+exit_status=$?
+
+if [ $exit_status -ne 1 ]
+then
+    echo Exit code is expected to be 1 but was $exit_status
+    echo 007 FAILED
+    STATUS=1
+fi
+
 # Cleanup
 after_all
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -139,6 +139,19 @@ then
     STATUS=1
 fi
 
+## 010: exit status code
+before_each
+
+$CMDSHELF cat nsc01 nsc02 2> /dev/null
+exit_status=$?
+
+if [ $exit_status -ne 1 ]
+then
+    echo Exit code is expected to be 1 but was $exit_status
+    echo 010 FAILED
+    STATUS=1
+fi
+
 # Cleanup
 after_all
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -126,7 +126,7 @@ fi
 
 rm $TMP_006 $TEST_006_SH
 
-## 007: exit status code
+## 007: [run] exit status code
 before_each
 
 $CMDSHELF run no-such-command 2> /dev/null
@@ -139,7 +139,7 @@ then
     STATUS=1
 fi
 
-## 008: exit status code
+## 008: [cat] exit status code
 before_each
 
 $CMDSHELF cat nsc01 nsc02 2> /dev/null


### PR DESCRIPTION
cmdshelf was always existing with status code 0.
It now sets exit code 1 on error.

expected errors:
- run: when specified executable is not found
- run: propagate executable's exit code
- cat: when specified executable(s) is not found