### PR TITLE
Add initial man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-.PHONY = clean update build test bootstrap sourcery
+.PHONY = clean update build test bootstrap
 SOURCERY ?= sourcery # Please install appropriate version on your own.
-MODULE_NAME = cmdshelf
-PARAM = SWIFTPM_DEVELOPMENT=YES
+PARAM = CMDSHELF_SWIFTPM_DEVELOPMENT=YES
 
 test:
 	$(PARAM) swift build
@@ -22,9 +21,9 @@ bootstrap: build
 
 # Needs toshi0383/scripts to be added to cmdshelf's remote
 install:
-	cmdshelf run "swiftpm/install.sh toshi0383/cmdshelf"
+	cmdshelf run swiftpm/install.sh toshi0383/cmdshelf
 
 release:
 	rm -rf .build/release
 	swift build -c release -Xswiftc -static-stdlib
-	cmdshelf run "swiftpm/release.sh cmdshelf libCYaml.dylib"
+	cmdshelf run swiftpm/release.sh cmdshelf libCYaml.dylib

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,9 @@
 import Foundation
 import PackageDescription
 
-var isDevelopment: Bool {
-	return ProcessInfo.processInfo.environment["SWIFTPM_DEVELOPMENT"] == "YES"
-}
+// var isDevelopment: Bool {
+// 	return ProcessInfo.processInfo.environment["CMDSHELF_SWIFTPM_DEVELOPMENT"] == "YES"
+// }
 
 let package = Package(
     name: "cmdshelf",

--- a/doc/man/man1/cmdshelf.1
+++ b/doc/man/man1/cmdshelf.1
@@ -1,0 +1,31 @@
+.TH "CMDSHELF" "1" "January 2018" "cmdshelf 0.9.0" "Cmdshelf Manual"
+.SH "NAME"
+\fBcmdshelf\fR - Manage your scripts like a bookshelf.
+.SH "SYNOPSIS"
+\fBcmdshelf\fR <\fBsub-command\fR> \fB...\fR
+.SH "OPTIONS"
+.TP
+\-h, \-\-help
+Show this help message. Type
+.B cmdshelf help sub-command
+to see more detailed manual page for each sub-command.
+.SH "SUB-COMMANDS"
+.SS blob
+Manage blob commands.
+.SS cat
+Concatenate and print sourcecodes of commands.
+.SS help
+Show help message.
+.SS list
+Show all registered commands.
+.SS remote
+Manage remote commands.
+.SS run
+Execute command.
+.SS update
+Update cloned repositories.
+.SH "WORKSPACE"
+.SS ~/.cmdshelf.yml
+Your current configuration is stored here. \fBcmdshelf\fR reads this file everytime it launches, writing on exit. Feel free to modify entries and run cmdshelf update to keep in sync.
+.SS ~/.cmdshelf/remote
+All repositories are cloned under this directory.


### PR DESCRIPTION
Distribute troff manual page.

Also updated [release.sh](https://github.com/toshi0383/scripts/blob/master/swiftpm/release.sh) to include man-pages.
Users can now install this man-page using [install.sh as documented in README](https://github.com/toshi0383/cmdshelf#installsh).
Mint could support installing man-pages as well, but it's not supported right now.