### PR TITLE
Add man1/cmdshelf.1 manual page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+##### Enhancements
+* Add man1/cmdshelf.1 manual page [#54](https://github.com/toshi0383/cmdshelf/pull/54)  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+
 ## 0.9.0
 ##### Bugfix & Breaking
 * [fixed] set error status code on error [#52](https://github.com/toshi0383/cmdshelf/pull/52)  

--- a/doc/man/man1/cmdshelf.1
+++ b/doc/man/man1/cmdshelf.1
@@ -1,0 +1,31 @@
+.TH "CMDSHELF" "1" "January 2018" "cmdshelf 0.9.0" "Cmdshelf Manual"
+.SH "NAME"
+\fBcmdshelf\fR - Manage your scripts like a bookshelf.
+.SH "SYNOPSIS"
+\fBcmdshelf\fR <\fBsub-command\fR> \fB...\fR
+.SH "OPTIONS"
+.TP
+\-h, \-\-help
+Show this help message. Type
+.B cmdshelf help sub-command
+to see more detailed manual page for each sub-command.
+.SH "SUB-COMMANDS"
+.SS blob
+Manage blob commands.
+.SS cat
+Concatenate and print sourcecodes of commands.
+.SS help
+Show help message.
+.SS list
+Show all registered commands.
+.SS remote
+Manage remote commands.
+.SS run
+Execute command.
+.SS update
+Update cloned repositories.
+.SH "WORKSPACE"
+.SS ~/.cmdshelf.yml
+Your current configuration is stored here. \fBcmdshelf\fR reads this file everytime it launches, writing on exit. Feel free to modify entries and run cmdshelf update to keep in sync.
+.SS ~/.cmdshelf/remote
+All repositories are cloned under this directory.


### PR DESCRIPTION
Distribute troff manual page.
https://github.com/toshi0383/cmdshelf/issues/46

<img width="654" alt="cmdshelf-54" src="https://user-images.githubusercontent.com/6007952/35184387-40f3f5ba-fe38-11e7-960e-8bf12214b36c.png">

Also updated [release.sh](https://github.com/toshi0383/scripts/blob/master/swiftpm/release.sh) to include man-pages.
Users can now install this man-page [using install.sh as documented in README](https://github.com/toshi0383/cmdshelf#installsh).
Mint could support installing man-pages as well, but it's not supported right now. => https://github.com/yonaskolb/Mint/issues/50