### PR TITLE
Use popen/pclose to spawn man-page pager process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## master
+##### Enhancements
+* Open man-pager on `help list` [#57](https://github.com/toshi0383/cmdshelf/pull/57)  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+
+* Add man1/cmdshelf-list.1 manual page [#56](https://github.com/toshi0383/cmdshelf/pull/56)  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+
 ## 0.9.1
 ##### Enhancements
 * Add man1/cmdshelf.1 manual page [#54](https://github.com/toshi0383/cmdshelf/pull/54)  

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
-// swift-tools-version:3.1
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import Foundation
 import PackageDescription
@@ -9,15 +10,27 @@ import PackageDescription
 
 let package = Package(
     name: "cmdshelf",
+    products: [
+        .executable(name: "cmdshelf", targets: ["cmdshelf"]),
+        .library(name: "Poxis", targets: ["Poxis"]),
+    ],
     dependencies: {
         let deps: [Package.Dependency] = [
-            .Package(url: "https://github.com/toshi0383/Commander.git", majorVersion: 0),
-            .Package(url: "https://github.com/toshi0383/PathKit.git", majorVersion: 0),
-            .Package(url: "https://github.com/toshi0383/Reporter.git", majorVersion: 0),
-            .Package(url: "https://github.com/jpsim/Yams.git", majorVersion: 0)
+            .package(url: "https://github.com/toshi0383/Commander.git", from: "0.9.0"),
+            .package(url: "https://github.com/toshi0383/PathKit.git", from: "0.8.0"),
+            .package(url: "https://github.com/toshi0383/Reporter.git", from: "0.3.2"),
+            .package(url: "https://github.com/jpsim/Yams.git", from: "0.5.0")
         ]
         return deps
     }(),
-    exclude: ["Resources/SourceryTemplates"]
+    targets: [
+        .target(name: "cmdshelf", dependencies: [
+            "Commander",
+            "PathKit",
+            "Poxis",
+            "Reporter",
+            "Yams",
+        ]),
+        .target(name: "Poxis", dependencies: [])
+    ]
 )
-

--- a/Sources/Poxis/include/Poxis.h
+++ b/Sources/Poxis/include/Poxis.h
@@ -1,0 +1,1 @@
+#include "include.h"

--- a/Sources/Poxis/include/Poxis.h
+++ b/Sources/Poxis/include/Poxis.h
@@ -1,1 +1,1 @@
-#include "include.h"
+#include "popen.h"

--- a/Sources/Poxis/include/include.h
+++ b/Sources/Poxis/include/include.h
@@ -1,0 +1,23 @@
+//
+//  popen.h
+//  cmdshelf
+//
+//  Created by Toshihiro Suzuki on 2018/01/01.
+//
+
+#ifndef popen_h
+#define popen_h
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+
+FILE *poxis_popen(const char *cmdstring, const char *type);
+int poxis_pclose(FILE *fp);
+long open_max(void);
+
+#endif /* popen_h */

--- a/Sources/Poxis/include/popen.h
+++ b/Sources/Poxis/include/popen.h
@@ -18,6 +18,5 @@
 
 FILE *poxis_popen(const char *cmdstring, const char *type);
 int poxis_pclose(FILE *fp);
-long open_max(void);
 
 #endif /* popen_h */

--- a/Sources/Poxis/src/Private.h
+++ b/Sources/Poxis/src/Private.h
@@ -1,0 +1,1 @@
+long open_max(void);

--- a/Sources/Poxis/src/popen.c
+++ b/Sources/Poxis/src/popen.c
@@ -1,4 +1,5 @@
-#include "include.h"
+#include "popen.h"
+#include "Private.h"
 
 /*
  * Pointer to array allocated at run-time.

--- a/Sources/Poxis/src/popen.c
+++ b/Sources/Poxis/src/popen.c
@@ -1,0 +1,140 @@
+#include "include.h"
+
+/*
+ * Pointer to array allocated at run-time.
+ */
+static pid_t	*childpid = NULL;
+
+/*
+ * From our open_max(), {Prog openmax}.
+ */
+static int		maxfd;
+
+FILE *
+poxis_popen(const char *cmdstring, const char *type)
+{
+	int		i;
+	int		pfd[2];
+	pid_t	pid;
+	FILE	*fp;
+
+	/* only allow "r" or "w" */
+	if ((type[0] != 'r' && type[0] != 'w') || type[1] != 0) {
+		errno = EINVAL;
+		return(NULL);
+	}
+
+	if (childpid == NULL) {		/* first time through */
+		/* allocate zeroed out array for child pids */
+		maxfd = open_max();
+		if ((childpid = calloc(maxfd, sizeof(pid_t))) == NULL)
+			return(NULL);
+	}
+
+	if (pipe(pfd) < 0)
+		return(NULL);	/* errno set by pipe() */
+	if (pfd[0] >= maxfd || pfd[1] >= maxfd) {
+		close(pfd[0]);
+		close(pfd[1]);
+		errno = EMFILE;
+		return(NULL);
+	}
+
+	if ((pid = fork()) < 0) {
+		return(NULL);	/* errno set by fork() */
+	} else if (pid == 0) {							/* child */
+		if (*type == 'r') {
+			close(pfd[0]);
+			if (pfd[1] != STDOUT_FILENO) {
+				dup2(pfd[1], STDOUT_FILENO);
+				close(pfd[1]);
+			}
+		} else {
+			close(pfd[1]);
+			if (pfd[0] != STDIN_FILENO) {
+				dup2(pfd[0], STDIN_FILENO);
+				close(pfd[0]);
+			}
+		}
+
+		/* close all descriptors in childpid[] */
+		for (i = 0; i < maxfd; i++)
+			if (childpid[i] > 0)
+				close(i);
+
+		execl("/bin/sh", "sh", "-c", cmdstring, (char *)0);
+		_exit(127);
+	}
+
+	/* parent continues... */
+	if (*type == 'r') {
+		close(pfd[1]);
+		if ((fp = fdopen(pfd[0], type)) == NULL)
+			return(NULL);
+	} else {
+		close(pfd[0]);
+		if ((fp = fdopen(pfd[1], type)) == NULL)
+			return(NULL);
+	}
+
+	childpid[fileno(fp)] = pid;	/* remember child pid for this fd */
+	return(fp);
+}
+
+int
+poxis_pclose(FILE *fp)
+{
+	int		fd, stat;
+	pid_t	pid;
+
+	if (childpid == NULL) {
+		errno = EINVAL;
+		return(-1);		/* popen() has never been called */
+	}
+
+	fd = fileno(fp);
+	if (fd >= maxfd) {
+		errno = EINVAL;
+		return(-1);		/* invalid file descriptor */
+	}
+	if ((pid = childpid[fd]) == 0) {
+		errno = EINVAL;
+		return(-1);		/* fp wasn't opened by popen() */
+	}
+
+	childpid[fd] = 0;
+	if (fclose(fp) == EOF)
+		return(-1);
+
+	while (waitpid(pid, &stat, 0) < 0)
+		if (errno != EINTR)
+			return(-1);	/* error other than EINTR from waitpid() */
+
+	return(stat);	/* return child's termination status */
+}
+
+#ifdef    OPEN_MAX
+static long    openmax = OPEN_MAX;
+#else
+static long    openmax = 0;
+#endif
+
+/*
+ * If OPEN_MAX is indeterminate, this might be inadequate.
+ */
+#define    OPEN_MAX_GUESS    256
+
+long
+open_max(void)
+{
+    if (openmax == 0) {        /* first time through */
+        errno = 0;
+        if ((openmax = sysconf(_SC_OPEN_MAX)) < 0) {
+            if (errno == 0)
+                openmax = OPEN_MAX_GUESS;    /* it's indeterminate */
+            else
+                fprintf(stderr, "sysconf error for _SC_OPEN_MAX");
+        }
+    }
+    return(openmax);
+}

--- a/Sources/cmdshelf/ArgumentParsers.swift
+++ b/Sources/cmdshelf/ArgumentParsers.swift
@@ -90,6 +90,10 @@ enum SubCommand: String {
             return nil
         }
     }
+
+    var possiblyHasManPage: Bool {
+        return [.list].contains(self)
+    }
 }
 
 struct SubCommandConvertibleArgument: ArgumentDescriptor {

--- a/Sources/cmdshelf/Functions.swift
+++ b/Sources/cmdshelf/Functions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Poxis
 import Reporter
 
 @discardableResult
@@ -41,4 +42,22 @@ func shellOut(to: String, argument: String? = nil, shouldPrintStdout: Bool = tru
     inPipe.fileHandleForWriting.writeabilityHandler = nil
     #endif
     return process.terminationStatus
+}
+
+/// TODO: improve error handling
+@discardableResult
+func spawnPager(cmdString: String) -> Int32 {
+    errno = 0
+    guard let fpin = poxis_popen(cmdString, "r") else {
+        return 1
+    }
+    guard let fpout = poxis_popen("more", "w") else {
+        return 1
+    }
+    var line: [Int8] = []
+    while fgets(&line, 4096, fpin) != nil {
+        fputs(&line, fpout)// == EOF then error
+    }
+    poxis_pclose(fpout)
+    return poxis_pclose(fpin)
 }

--- a/Sources/cmdshelf/main.swift
+++ b/Sources/cmdshelf/main.swift
@@ -57,7 +57,13 @@ func printHelpMessage() {
 
 let help = command(SubCommandArgument()) { (subCommand) in
     if let subCommand = subCommand {
-        queuedPrintln(subCommand.helpMessage)
+        if subCommand.possiblyHasManPage {
+            if spawnPager(cmdString: "man cmdshelf-\(subCommand.rawValue)") != 0 {
+                queuedPrintln(subCommand.helpMessage)
+            }
+        } else {
+            queuedPrintln(subCommand.helpMessage)
+        }
         return
     }
     printHelpMessage()


### PR DESCRIPTION
popen/pclose is prohibited in Swift, but it turns out that it's not, when implemented in pure C, by yourself.😛
I implemented them in new module called `Poxis`, then use them to spawn editor process, currently for man-page purpose.

I'm doing this because I couldn't implement this feature using `NSTask`.

Related:
- https://github.com/toshi0383/cmdshelf/issues/15
- https://github.com/toshi0383/cmdshelf/issues/46