### PR TITLE
Update Reporter 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+##### Enhancement
+* improve `update` command output [#63](https://github.com/toshi0383/cmdshelf/pull/63)  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+
 ## 0.9.3
 ##### Bugfix
 * fix crash on empty runner [#61](https://github.com/toshi0383/cmdshelf/pull/61)  

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/toshi0383/Reporter.git",
         "state": {
           "branch": null,
-          "revision": "b48953a430185769071724ffb1835a180ae59301",
-          "version": "0.3.2"
+          "revision": "c21ecca72a9a5e1b32b74d03615187c442dc281a",
+          "version": "0.4.0"
         }
       },
       {


### PR DESCRIPTION
`queuedPrint` (print without new-line) wasn't flushing the buffer.
Now it does flush everytime, regardless of kernel's buffering mode.