### PR TITLE
Bash completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+##### Enhancement
+* Bash completion [#71](https://github.com/toshi384/cmdshelf/pull/71)  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+
 ## 0.9.5
 ##### Enhancement
 * short names for subcommands [#68](https://github.com/toshi384/cmdshelf/pull/68)  

--- a/README.md
+++ b/README.md
@@ -33,11 +33,31 @@ cmdshelf is a new way of scripting.😎
 
 You can see detailed document [here](doc/getting-started.md), or type `man cmdshelf`.
 
-# Pro tip: set aliases
+# Pro tip
+## set aliases
 Put this in your `.bashrc`. You don't have to type "cmdshelf" each time.
 ```
 alias run='cmdshelf run'
 alias list='cmdshelf list'
+```
+
+## Use auto bash-completion
+In case of binary install suggested [here](#installsh), `cmdshelf-completion.bash` is copied under `/usr/local/etc/bash-completion.d`. All you have to do is to make bash be aware of that file.
+
+Either put this in your `~/.bashrc`,
+```shell
+source /usr/local/etc/bash_completion.d/cmdshelf-completion.bash
+```
+
+or install `bash-completion` via homebrew. (Personally I've never managed it to work correctly.)
+
+If you build from source either via `Mint` or manually, then you first have to copy or symlink it manually.
+```shell
+# copy
+cp Sources/Scripts/cmdshelf-completion.bash /usr/local/etc/bash-completion.d/
+
+# or simlink
+ln -s Sources/Scripts/cmdshelf-completion.bash /usr/local/etc/bash-completion.d/cmdshelf-completion.bash
 ```
 
 # Install
@@ -58,7 +78,7 @@ mint install toshi0383/cmdshelf
 
 Please build from source-code if `install.sh` didn't work.
 
-- Clone this repo and run `swift build -c release`.  
+- Clone this repo and run `swift build -c release`.
 - Executable will be created at `.build/release/cmdshelf`.
 - `mv .build/release/cmdshelf /usr/local/bin/`
 

--- a/Sources/Scripts/cmdshelf-completion.bash
+++ b/Sources/Scripts/cmdshelf-completion.bash
@@ -30,7 +30,7 @@ _cmdshelf() {
             return 0
             ;;
         run)
-            COMPREPLY=($(compgen -W "$(cmdshelf list)" -- ${cur}))
+            COMPREPLY=($(compgen -W "$(cmdshelf list | grep -v ':')" -- ${cur}))
             return 0
             ;;
     esac

--- a/Sources/Scripts/cmdshelf-completion.bash
+++ b/Sources/Scripts/cmdshelf-completion.bash
@@ -1,0 +1,39 @@
+# Bash completion script for cmdshelf.
+
+_cmdshelf() {
+    local commands command cur prev
+    commands="blob cat list ls remote run update"
+
+    command="${COMP_WORDS[1]}"
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [ $COMP_CWORD == 1 ]
+    then
+        COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+        return 0
+    fi
+
+    if [ $COMP_CWORD == 2 -a "${command}" == help ]
+    then
+        COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+        return 0
+    fi
+
+    case "${command}" in
+        blob|remote)
+            COMPREPLY=($(compgen -W 'add list remove' -- ${cur}))
+            return 0
+            ;;
+        list|ls)
+            COMPREPLY=($(compgen -W '--path' -- ${cur}))
+            return 0
+            ;;
+        run)
+            COMPREPLY=($(compgen -W "$(cmdshelf list)" -- ${cur}))
+            return 0
+            ;;
+    esac
+}
+
+complete -F _cmdshelf cmdshelf


### PR DESCRIPTION
Added bash completion.

![cmdshelf-cmpletion](https://user-images.githubusercontent.com/6007952/41893415-9c4d53e0-7956-11e8-8623-00ae776139e2.gif)

Currently remote namespace is not supported by completion.

e.g. 
Cannot do this right now.
```
cmdshelf run myremote:[tab to complete]
```

I'm not planning Fish and Zsh completion support like [Carthage does](https://github.com/Carthage/Carthage/blob/master/Documentation/BashZshFishCompletion.md), but PRs are welcomed.👌

NOTE: Depends on [these scripts](https://github.com/toshi0383/scripts/tree/master/swiftpm) on binary release and install.