### PR TITLE
Use `dyn Trait` syntax to express a trait object

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,11 +17,11 @@ pub trait Runnable {
     fn run(&mut self, args: Vec<String>) -> Result<i32, String>;
 }
 
-pub fn help_command() -> Box<Runnable + 'static> {
+pub fn help_command() -> Box<dyn Runnable + 'static> {
     Box::new(Help { })
 }
 
-pub fn sub_command(string: &str) -> Result<Box<Runnable + 'static>, String> {
+pub fn sub_command(string: &str) -> Result<Box<dyn Runnable + 'static>, String> {
     match string.as_ref() {
         "cat"    => Ok(Box::new(Cat { })),
         "list"   => Ok(Box::new(List { })),

--- a/src/commands/remote.rs
+++ b/src/commands/remote.rs
@@ -23,7 +23,7 @@ impl Runnable for Remote {
 
 }
 
-fn sub_command(arg: &str) -> Result<Box<Runnable + 'static>, String> {
+fn sub_command(arg: &str) -> Result<Box<dyn Runnable + 'static>, String> {
     match arg {
         "add"    => Ok(Box::new(Add { })),
         "remove" => Ok(Box::new(Remove { })),

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     let args_remainder = _args.split_off(2);
 
     let status = commands::sub_command(&_args[1])
-        .and_then(|mut sub_command: Box<Runnable + 'static>| -> Result<i32, String> {
+        .and_then(|mut sub_command: Box<dyn Runnable + 'static>| -> Result<i32, String> {
             sub_command.run(args_remainder)
                 .or_else(|msg| {
                     reporter::error(format!("cmdshelf {}: {} ", sub_command.name(), msg));


### PR DESCRIPTION
* This new syntax is introduced by [Rust v1.27](https://blog.rust-lang.org/2018/06/21/Rust-1.27.html).