### PR TITLE
[bash-completion] support file path completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ You can see detailed document [here](docs/getting-started.md), or type `man cmds
 brew install cmdshelf
 ```
 
+It's recommended to [upgrade your bash to version 4](https://troymccall.com/better-bash-4--completions-on-osx/), to use full feature of cmdshelf's bash-completion.  
+See: https://github.com/toshi0383/cmdshelf/pull/88
+
 ## Build from source
 With Rust's package manager [cargo](https://github.com/rust-lang/cargo), you can install cmdshelf via:
 

--- a/cmdshelf-completion.bash
+++ b/cmdshelf-completion.bash
@@ -26,18 +26,31 @@ _cmdshelf() {
             return 0
             ;;
         list|ls)
-            COMPREPLY=($(compgen -W '--path' -- ${cur}))
+            COMPREPLY=($(compgen -W '--path' -- "${cur}"))
             return 0
             ;;
         run)
-            COMPREPLY=($(compgen -W "$(cmdshelf list | awk -F: '{print $2}')" -- ${cur}))
+            if [ $COMP_CWORD -le 2 ]; then
+                COMPREPLY=($(compgen -W "$(cmdshelf list | awk -F: '{print $2}')" -- "${cur}"))
+            else
+
+                # NOTE: available on bash 4 or later
+                compopt -o filenames cmdshelf 2>/dev/null
+                compgen -f /non-existing-dir/ >/dev/null
+
+                COMPREPLY=($(compgen -df -- "$cur"))
+            fi
+
             return 0
             ;;
         cat)
-            COMPREPLY=($(compgen -W "$(cmdshelf list | awk -F: '{print $2}')" -- ${cur}))
+            COMPREPLY=($(compgen -W "$(cmdshelf list | awk -F: '{print $2}')" -- "${cur}"))
+
             return 0
             ;;
     esac
 }
 
-complete -F _cmdshelf cmdshelf
+# https://www.gnu.org/software/bash/manual/html_node/A-Programmable-Completion-Example.html
+
+complete -o bashdefault -F _cmdshelf cmdshelf


### PR DESCRIPTION
Fix https://github.com/toshi0383/cmdshelf/issues/87

Uses `compopt` to use file mode on bash 4 or later.